### PR TITLE
Use cloudfront link to rawvideo object in S3

### DIFF
--- a/src/VimeoUploadLambda/index.js
+++ b/src/VimeoUploadLambda/index.js
@@ -2,7 +2,7 @@ import mysql from 'mysql';
 import req from 'request';
 
 const uploadToVimeo = (bucket, video) => {
-  const videoLink = `https://s3.amazonaws.com/${bucket}/${video}`;
+  const videoLink = `${getCloudfrontName(bucket)}/${video}`;
   console.log("uploading " + videoLink + " to vimeo")
 
   req(
@@ -31,6 +31,10 @@ const uploadToVimeo = (bucket, video) => {
     },
   );
 };
+
+const getCloudfrontName = (bucket) => {
+  `https://${bucket.replace('execonline-', '')}.execonline.com`
+}
 
 const updateAsset = (vimeoId, video) => {
   const connection = mysql.createConnection({


### PR DESCRIPTION
This is part of the effort to make the S3 buckets private. This lambda function uploads to Vimeo using a link to the EP User uploaded original in S3. Currently, the direct to bucket link is being used, which requires that the object is public (and by extension, accessible to anyone with the link for viewing or download).
This change updates the original video link to go through CloudFront, which will allow the object (and bucket) to be made private but still accessible with this new link. The direct to bucket link will no longer be accessible.
Some of the advantages or using CloudFront:
- bucket can be made private, objects as well
- S3 bucket names are no longer being exposed
- even more secure protections can be implemented down the line (like signed urls)